### PR TITLE
Disable debug output.

### DIFF
--- a/include/autoconf.h
+++ b/include/autoconf.h
@@ -286,7 +286,7 @@
 /*
  * Debug Related Config
  */
-#define CONFIG_DEBUG
+#undef CONFIG_DEBUG
 
 #ifdef CONFIG_DEBUG
 #define DBG	1	// for ODM & BTCOEX debug


### PR DESCRIPTION
With CONFIG_DEBUG the driver generates far too many messages.
Disabling these messages makes it harder to debug failures but it
increases the performance quite a bit.