### PR TITLE
fix priv_destructor -> destructor for lenovo 100s

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3951,7 +3951,7 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
-	mon_ndev->priv_destructor = rtw_ndev_destructor;
+	mon_ndev->destructor = rtw_ndev_destructor;
 	
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,29))
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;


### PR DESCRIPTION
Just fix some changes in the struct status variable.

`//mon_ndev->priv_destructor = rtw_ndev_destructor;
mon_ndev->destructor = rtw_ndev_destructor;`